### PR TITLE
feat: Add news section for announcements and releases

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -55,6 +55,29 @@ const config: Config = {
     ],
   ],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-content-blog',
+      {
+        id: 'news',
+        path: './news',
+        routeBasePath: 'news',
+        blogTitle: 'T-Ruby News',
+        blogDescription: 'Release notes, announcements, and project updates',
+        blogSidebarTitle: 'Recent News',
+        blogSidebarCount: 10,
+        postsPerPage: 10,
+        showReadingTime: false,
+        editUrl: 'https://github.com/type-ruby/t-ruby.github.io/tree/main/',
+        feedOptions: {
+          type: ['rss', 'atom'],
+          xslt: true,
+          copyright: `Copyright ${new Date().getFullYear()} T-Ruby.`,
+        },
+      },
+    ],
+  ],
+
   themeConfig: {
     image: 'img/t-ruby-social-card.png',
     colorMode: {
@@ -77,6 +100,11 @@ const config: Config = {
         {
           to: '/playground',
           label: 'Playground',
+          position: 'left',
+        },
+        {
+          to: '/news',
+          label: 'News',
           position: 'left',
         },
         {
@@ -116,6 +144,10 @@ const config: Config = {
             {
               label: 'Playground',
               to: '/playground',
+            },
+            {
+              label: 'News',
+              to: '/news',
             },
             {
               label: 'Type Cheatsheet',

--- a/i18n/ja/docusaurus-plugin-content-blog-news/2025-12-24-introducing-t-ruby.md
+++ b/i18n/ja/docusaurus-plugin-content-blog-news/2025-12-24-introducing-t-ruby.md
@@ -1,0 +1,41 @@
+---
+slug: introducing-t-ruby
+title: T-Ruby のご紹介
+authors: [t-ruby-team]
+tags: [announcement]
+---
+
+Ruby 向けの TypeScript スタイル静的型システム、T-Ruby をご紹介します。
+
+T-Ruby は、TypeScript 開発者にとって馴染みのある開発体験を Ruby 開発者に提供し、コードに直接型アノテーションを追加して、ランタイム前に型エラーを検出できるようにします。
+
+## 主な機能
+
+- **TypeScript スタイルの構文**: TypeScript 開発者に馴染みのある型アノテーション構文
+- **段階的な型付け**: 既存の Ruby コードベースに段階的に型を追加可能
+- **RBS 生成**: `.rbs` シグネチャファイルの自動生成
+- **ゼロランタイムオーバーヘッド**: コンパイル時に型が削除される
+
+## はじめに
+
+T-Ruby をインストールして、Ruby コードに型を追加しましょう：
+
+```bash
+gem install t-ruby
+```
+
+最初の `.trb` ファイルを作成します：
+
+```ruby
+def greet(name: String): String
+  "Hello, #{name}!"
+end
+```
+
+Ruby にコンパイル：
+
+```bash
+trc greet.trb
+```
+
+詳細については、[ドキュメント](/docs/introduction/what-is-t-ruby)をご覧ください！

--- a/i18n/ja/docusaurus-plugin-content-blog-news/authors.yml
+++ b/i18n/ja/docusaurus-plugin-content-blog-news/authors.yml
@@ -1,0 +1,4 @@
+t-ruby-team:
+  name: T-Ruby チーム
+  url: https://github.com/type-ruby
+  image_url: /img/logo.svg

--- a/i18n/ko/docusaurus-plugin-content-blog-news/2025-12-24-introducing-t-ruby.md
+++ b/i18n/ko/docusaurus-plugin-content-blog-news/2025-12-24-introducing-t-ruby.md
@@ -1,0 +1,41 @@
+---
+slug: introducing-t-ruby
+title: T-Ruby 소개
+authors: [t-ruby-team]
+tags: [announcement]
+---
+
+Ruby를 위한 TypeScript 스타일 정적 타입 시스템, T-Ruby를 소개합니다.
+
+T-Ruby는 TypeScript 개발자에게 익숙한 개발 경험을 Ruby 개발자에게 제공하여, 코드에 직접 타입 어노테이션을 추가하고 런타임 전에 타입 오류를 감지할 수 있게 합니다.
+
+## 주요 기능
+
+- **TypeScript 스타일 문법**: TypeScript 개발자에게 익숙한 타입 어노테이션 문법
+- **점진적 타이핑**: 기존 Ruby 코드베이스에 점진적으로 타입 추가 가능
+- **RBS 생성**: `.rbs` 시그니처 파일 자동 생성
+- **제로 런타임 오버헤드**: 컴파일 시 타입이 제거됨
+
+## 시작하기
+
+T-Ruby를 설치하고 Ruby 코드에 타입을 추가해보세요:
+
+```bash
+gem install t-ruby
+```
+
+첫 번째 `.trb` 파일을 작성합니다:
+
+```ruby
+def greet(name: String): String
+  "Hello, #{name}!"
+end
+```
+
+Ruby로 컴파일:
+
+```bash
+trc greet.trb
+```
+
+더 자세한 내용은 [문서](/docs/introduction/what-is-t-ruby)를 확인하세요!

--- a/i18n/ko/docusaurus-plugin-content-blog-news/authors.yml
+++ b/i18n/ko/docusaurus-plugin-content-blog-news/authors.yml
@@ -1,0 +1,4 @@
+t-ruby-team:
+  name: T-Ruby 팀
+  url: https://github.com/type-ruby
+  image_url: /img/logo.svg

--- a/news/2025-12-24-introducing-t-ruby.md
+++ b/news/2025-12-24-introducing-t-ruby.md
@@ -1,0 +1,41 @@
+---
+slug: introducing-t-ruby
+title: Introducing T-Ruby
+authors: [t-ruby-team]
+tags: [announcement]
+---
+
+We're excited to introduce T-Ruby, a TypeScript-style static type system for Ruby.
+
+T-Ruby brings the familiar TypeScript development experience to Ruby developers, allowing you to add type annotations directly in your code and catch type errors before runtime.
+
+## Key Features
+
+- **TypeScript-style syntax**: Familiar type annotation syntax for TypeScript developers
+- **Gradual typing**: Add types incrementally to your existing Ruby codebase
+- **RBS generation**: Automatically generate `.rbs` signature files
+- **Zero runtime overhead**: Types are stripped at compile time
+
+## Getting Started
+
+Install T-Ruby and start adding types to your Ruby code:
+
+```bash
+gem install t-ruby
+```
+
+Create your first `.trb` file:
+
+```ruby
+def greet(name: String): String
+  "Hello, #{name}!"
+end
+```
+
+Compile to Ruby:
+
+```bash
+trc greet.trb
+```
+
+Check out our [documentation](/docs/introduction/what-is-t-ruby) to learn more!

--- a/news/authors.yml
+++ b/news/authors.yml
@@ -1,0 +1,4 @@
+t-ruby-team:
+  name: T-Ruby Team
+  url: https://github.com/type-ruby
+  image_url: /img/logo.svg


### PR DESCRIPTION
## Summary

This PR adds a news section to the T-Ruby documentation site for project announcements and release notes.

## Changes

- Add `@docusaurus/plugin-content-blog` as a secondary blog plugin with id `news`
- Create `news/` directory with sample announcement post
- Add "News" link to navbar (between Playground and locale dropdown)
- Add "News" link to footer Resources section
- Add Korean and Japanese translations for news content

## Features

- **Route**: `/news`
- **RSS/Atom feeds**: Available at `/news/rss.xml` and `/news/atom.xml`
- **Multi-language support**: English, Korean, Japanese
- **No reading time**: Optimized for short-form content

## Testing

- [x] Build succeeds for all locales (en, ko, ja)
- [x] News page accessible at `/news`
- [x] Navbar and footer links work correctly

Closes #3