### PR TITLE
Fix strong text colors when using dark mode

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -189,7 +189,7 @@
 }
 
 .whatIsItem p strong {
-  color: initial;
+  color: var(--ifm-font-color-base);
   font-weight: 900;
 }
 


### PR DESCRIPTION
How it currently looks:
<img width="1080" height="349" alt="Black text on a dark background" src="https://github.com/user-attachments/assets/a11bbd4e-7768-4f06-8dde-bacb07ad877c" />
