### PR TITLE
docs: rephrase language on splash page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -105,7 +105,7 @@ function WhatIsTRuby() {
               dangerouslySetInnerHTML={{
                 __html: translate({
                   id: 'homepage.whatIs.rubyMore.description',
-                  message: 'T-Ruby extends Ruby with additional syntax. <strong>This means static types and compile time.</strong>',
+                  message: 'T-Ruby extends Ruby with additional syntax. <strong>This means static types at compile time.</strong>',
                 }),
               }}
             />


### PR DESCRIPTION
This pull request updates the language on the splash to indicate that the tool
provides static types _at compile time_ rather than _and compile time_ (unless
that is the intended language, in which case ignore this!).
